### PR TITLE
fix: SEO Patch for Schema.Org logo

### DIFF
--- a/src/components/SEO/SchemaOrg.js
+++ b/src/components/SEO/SchemaOrg.js
@@ -61,7 +61,10 @@ export default React.memo(
             publisher: {
               '@type': 'Organization',
               url: organization.url,
-              logo: organization.logo,
+              logo: {
+                '@type': 'ImageObject',
+                url: organization.logo
+              },
               name: organization.name,
             },
             mainEntityOfPage: {


### PR DESCRIPTION
I've applied a patch for schema.org publisher values (specifically the logo value). 
According to the [Google Testing Tool](https://search.google.com/structured-data/testing-tool/) you need to specify the type for the logo. 
It is also advisable to insert a height and a width inside the logo, but not necessarily.